### PR TITLE
Update to .NET 8.0 and clean up project file

### DIFF
--- a/TWPC.ClubWebsite.UI/TWPC.ClubWebsite.UI.csproj
+++ b/TWPC.ClubWebsite.UI/TWPC.ClubWebsite.UI.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" PrivateAssets="all" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="wwwroot\sample-data\" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Updated TWPC.ClubWebsite.UI.csproj to target .NET 8.0. Changed <TargetFramework> from net6.0 to net8.0.
Upgraded package references for Microsoft.AspNetCore.Components.WebAssembly and Microsoft.AspNetCore.Components.WebAssembly.DevServer from 6.0.10 to 8.0.11. Removed unnecessary <ItemGroup> with folder reference to wwwroot/sample-data/.